### PR TITLE
feat: sort dropdown fixed + feature flag removed

### DIFF
--- a/src/components/results/Results.tsx
+++ b/src/components/results/Results.tsx
@@ -39,17 +39,20 @@ const Results: React.FC = () => {
     SortOptionType.DueDateNewToOld
   );
 
+  // On load set sorting new to old
   useEffect(() => {
     setSortOption(SortOptionType.DueDateNewToOld);
     setLoading(false);
-  }, [filteredResults]);
+  }, []);
 
+  // Everytime sortOption or setFilteredResults changes sort filteredResults
   useEffect(() => {
     setFilteredResults((filteredResults) =>
       sortListBy(filteredResults, sortOption)
     );
   }, [sortOption, setFilteredResults]);
 
+  // results card element
   const renderResults = () => {
     if (filteredResults.length === 0) {
       return (
@@ -78,10 +81,7 @@ const Results: React.FC = () => {
           <RightSide onClick={() => setIsFilterOpen(false)}>
             <MatchSortContainer>
               <ResultsMatched>{`${filteredResults.length} matches:`}</ResultsMatched>
-              {process.env.REACT_APP_SHOW_SORT &&
-                process.env.REACT_APP_SHOW_SORT === "true" && (
-                  <SortDropdown setSortOption={setSortOption} />
-                )}
+                <SortDropdown setSortOption={setSortOption} />
             </MatchSortContainer>
             <ResultsList>{renderResults()}</ResultsList>
           </RightSide>

--- a/src/components/results/sort/sortListBy.test.ts
+++ b/src/components/results/sort/sortListBy.test.ts
@@ -151,14 +151,14 @@ describe("sortListBy", () => {
     });
 
     it("sorts results from oldest deadline to newest deadline when sort option is DueDateOldToNew", () => {
-      const answer: Result[] = [result3, result2, result1, result4, result5];
+      const answer: Result[] = [result1, result2, result3, result4, result5];
       expect(sortListBy(results, SortOptionType.DueDateOldToNew)).toEqual(
         answer
       );
     });
 
     it("sorts results from newest deadline to oldest deadline when sort option is DueDateNewToOld", () => {
-      const answer: Result[] = [result1, result2, result3, result4, result5];
+      const answer: Result[] = [result3, result2, result1, result4, result5];
       expect(sortListBy(results, SortOptionType.DueDateNewToOld)).toEqual(
         answer
       );

--- a/src/components/results/sort/sortListBy.ts
+++ b/src/components/results/sort/sortListBy.ts
@@ -2,9 +2,10 @@ import {SortOptionType, Result, SupportType} from "../../../types";
 import Moment from "moment";
 
 /**
+ * TODO use lodash
  * Sorts a copy of the given list with the given option and returns the copy.
- * @param list of results
- * @param option sort option type
+ * @param {Result[]} list - filteredResults from ../Results.tsx
+ * @param {SortOptionType} option - Sort order
  */
 export default (list: Result[], option: SortOptionType): Result[] => {
   const sortedList = [...list];
@@ -106,7 +107,7 @@ export default (list: Result[], option: SortOptionType): Result[] => {
         if (a.deadline === null && b.deadline === null) {
           return 0;
         }
-        return Moment(b.deadline).diff(Moment(a.deadline));
+        return Moment(a.deadline).diff(Moment(b.deadline));
       });
       break;
     case SortOptionType.DueDateNewToOld:
@@ -120,7 +121,7 @@ export default (list: Result[], option: SortOptionType): Result[] => {
         if (a.deadline === null && b.deadline === null) {
           return 0;
         }
-        return Moment(a.deadline).diff(Moment(b.deadline));
+        return Moment(b.deadline).diff(Moment(a.deadline));
       });
       break;
     case SortOptionType.None:


### PR DESCRIPTION
1. useEffect was setting the same sort order every time filteredResult changed. So every attempt to change resulted in initial result
2. sortListBy.test.ts answers for deadline order were reversed.
3. sortListBy.ts deadline sorting reversed.